### PR TITLE
kokkos build instructions, kokkos required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,9 @@ macro(gitrmsheath_export_lib target headers)
   install(FILES ${headers} DESTINATION include)
 endmacro(gitrmsheath_export_lib)
 
-
-find_package(Kokkos)
+#kokkos does not allow extensions
+set(CMAKE_CXX_EXTENSIONS Off)
+find_package(Kokkos REQUIRED)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/README.md
+++ b/README.md
@@ -91,14 +91,42 @@ Install with OpenMP backend
 
 ### Building for GPU execution
 
+Create a file named `doConfigGitrmSheathGpu.sh` with the following contents:
+
 ```
 bdir=$PWD/build-GPU
 cmake -S gitrm-sheath -B $bdir \
 -DKokkos_DIR=$PWD/buildKokkosCUDA/install/lib64/cmake/Kokkos \
 -DCMAKE_CXX_COMPILER=$PWD/buildKokkosCUDA/install/bin/nvcc_wrapper \
 -DCMAKE_INSTALL_PREFIX=$bdir/install
+```
+
+Create a file named `buildGitrmSheathGpu.sh` with the following contents:
+
+```
+bdir=$PWD/build-GPU
 cmake --build $bdir --target install
 ```
+
+Make them executable:
+
+```
+chmod +x doConfigGitrmSheathGpu.sh buildGitrmSheathGpu.sh
+```
+
+Run the configure script then run the build script:
+
+```
+./doConfigGitrmSheathGpu.sh
+./buildGitrmSheathGpu.sh
+```
+
+To rebuild the code after making some changes:
+
+```
+./buildGitrmSheathGpu.sh
+```
+
 
 ### Building for CPU execution
 

--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ cmake --build $bdir --target install
 Run with OpenMP on CPU
 
 ```
-./build-omp/install/bin/GitrmSheath_Demo
+./build-omp/test/GitrmSheathWachspress_Demo
 ```
 
 Run with CUDA on GPU
 
 ```
-./build-GPU/install/bin/GitrmSheath_Demo
+./build-GPU/test/GitrmSheathWachspress_Demo
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ cuda/11.4
 
 ### Install Kokkos
 
+Clone the repo
+
+```
+git clone https://github.com/Kokkos/kokkos.git
+```
+
 Create a file named `installKokkos.sh` with the following contents:
 
 ```

--- a/README.md
+++ b/README.md
@@ -39,27 +39,82 @@ cmake/3.20.0  \
 cuda/11.4
 ```
 
-Building with GPU
-```
-mkdir build-GPU
-cd build-GPU
-export CMAKE_PREFIX_PATH=$kk/lib64/cmake/Kokkos:$CMAKE_PREFIX_PATH
-cmake ../gitrm-sheath -DCMAKE_CXX_COMPILER=$kk_compiler -DCMAKE_INSTALL_PREFIX=$PWD/install # on GPU
-make -j 8
-make install
-```
+### Install Kokkos
 
-Building with OpenMP
-```
-mkdir build-omp
-cd build-omp
-export CMAKE_PREFIX_PATH=$kk/lib64/cmake/Kokkos:$CMAKE_PREFIX_PATH
-cmake ../gitrm-sheath -DCMAKE_INSTALL_PREFIX=$PWD/install # on OpenMP
-make -j 8
-make install
-```
-## test
+Create a file named `installKokkos.sh` with the following contents:
 
 ```
-./install/bin/GitrmSheath_Demo
+bkend=$1
+d=buildKokkos${bkend}
+omp=""
+cuda=""
+[[ ${bkend} == "OPENMP" ]] && omp="-DKokkos_ENABLE_OPENMP=on"
+[[ ${bkend} == "CUDA" ]] && cuda="-DKokkos_ENABLE_CUDA=on -DKokkos_ENABLE_CUDA_LAMBDA=on"
+[[ ${bkend} == "OPENMP_CUDA" ]] && ompcuda="-DKokkos_ENABLE_OPENMP=on -DKokkos_ENABLE_CUDA=on -DKokkos_ENABLE_CUDA_LAMBDA=on"
+cmake -S kokkos -B $d \
+  -DCMAKE_CXX_COMPILER=g++ \
+  -DKokkos_ARCH_TURING75=ON \
+  -DBUILD_SHARED_LIBS=ON \
+  $omp \
+  $cuda \
+  $ompcuda \
+  -DKokkos_ENABLE_SERIAL=ON \
+  -DKokkos_ENABLE_DEBUG=on \
+  -DKokkos_ENABLE_TESTS=off \
+  -DCMAKE_INSTALL_PREFIX=$d/install
+cmake --build $d -j 8 --target install
 ```
+
+Make it executable:
+
+```
+chmod +x installKokkos.sh
+```
+
+Install with CUDA backend
+
+```
+./installKokkos.sh CUDA
+```
+
+Install with OpenMP backend
+
+```
+./installKokkos.sh OPENMP
+```
+
+### Building for GPU execution
+
+```
+bdir=$PWD/build-GPU
+cmake -S gitrm-sheath -B $bdir \
+-DKokkos_DIR=$PWD/buildKokkosCUDA/install/lib64/cmake/Kokkos \
+-DCMAKE_CXX_COMPILER=$PWD/buildKokkosCUDA/install/bin/nvcc_wrapper \
+-DCMAKE_INSTALL_PREFIX=$bdir/install
+cmake --build $bdir --target install
+```
+
+### Building for CPU execution
+
+```
+bdir=$PWD/build-omp
+cmake -S gitrm-sheath -B $bdir \
+-DKokkos_DIR=$PWD/buildKokkosOPENMP/install/lib64/cmake/Kokkos \
+-DCMAKE_INSTALL_PREFIX=$bdir/install
+cmake --build $bdir --target install
+```
+
+## Run test
+
+Run with OpenMP on CPU
+
+```
+./build-omp/install/bin/GitrmSheath_Demo
+```
+
+Run with CUDA on GPU
+
+```
+./build-GPU/install/bin/GitrmSheath_Demo
+```
+


### PR DESCRIPTION
This PR adds Kokkos build instructions to the README and in the CMakeLists.txt
- sets Kokkos as required and
- disables C++ extensions as required by Kokkos.